### PR TITLE
feat: add hasIntegration utility

### DIFF
--- a/.changeset/selfish-months-fry.md
+++ b/.changeset/selfish-months-fry.md
@@ -2,4 +2,4 @@
 "astro-integration-kit": patch
 ---
 
-Adds hasIntegration util
+Adds the `hasIntegration` utility

--- a/.changeset/selfish-months-fry.md
+++ b/.changeset/selfish-months-fry.md
@@ -1,0 +1,5 @@
+---
+"astro-integration-kit": patch
+---
+
+Adds hasIntegration util

--- a/docs/src/content/docs/utilities/has-integration.mdx
+++ b/docs/src/content/docs/utilities/has-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: hasIntegration
-description: Checks whether an integration is already installed
+description: Checks whether an integration been added to the Astro config.
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 

--- a/docs/src/content/docs/utilities/has-integration.mdx
+++ b/docs/src/content/docs/utilities/has-integration.mdx
@@ -4,7 +4,7 @@ description: Checks whether an integration is already installed
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-`hasIntegration` checks whether an integration has already been installed and simply returns a boolean.
+`hasIntegration` checks whether an integration has already been added to the Astro config. For example:
 
 <Tabs>
     <TabItem label="All-in">
@@ -35,12 +35,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 			name: "my-integration",
 			hooks: {
 				"astro:config:setup": ({ config }) => {
-					const tailwindIsInstalled = hasIntegration({
+					if (hasIntegration({
 						name: "@astrojs/tailwind",
 						config,
-					});
-
-					if (tailwindIsInstalled) {
+					})) {
 						console.log("Tailwind already installed")
 					}
 				},

--- a/docs/src/content/docs/utilities/has-integration.mdx
+++ b/docs/src/content/docs/utilities/has-integration.mdx
@@ -1,0 +1,52 @@
+---
+title: hasIntegration
+description: Checks whether an integration is already installed
+---
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+`hasIntegration` checks whether an integration has already been installed and simply returns a boolean.
+
+<Tabs>
+    <TabItem label="All-in">
+	```ts title="my-integration/index.ts"
+	import { hasIntegration } from "astro-integration-kit";
+
+	export default defineIntegration({
+		name: "my-integration",
+		setup() {
+			return {
+				"astro:config:setup": () => {
+					if (hasIntegration("@astrojs/tailwind")) {
+						console.log("Tailwind already installed");
+					}
+				}
+			}
+		}
+	})
+	```
+	</TabItem>
+	<TabItem label="Vanilla">
+	```ts title="integration/index.ts"
+	import type { AstroIntegration } from "astro";
+	import { hasIntegration } from "astro-integration-kit/vanilla";
+
+	export default function myIntegration(): AstroIntegration {
+		return {
+			name: "my-integration",
+			hooks: {
+				"astro:config:setup": ({ config }) => {
+					const tailwindIsInstalled = hasIntegration({
+						name: "@astrojs/tailwind",
+						config,
+					});
+
+					if (tailwindIsInstalled) {
+						console.log("Tailwind already installed")
+					}
+				},
+			}
+		}
+	}
+	``` 
+	</TabItem>
+</Tabs>

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -2,5 +2,5 @@ export { addVirtualImport } from "./utils/add-virtual-import.js";
 export { addVitePlugin } from "./utils/add-vite-plugin.js";
 export { createResolver } from "./utils/create-resolver.js";
 export { defineIntegration } from "./utils/define-integration.js";
-export { watchIntegration } from "./utils/watch-integration.js";
 export { hasIntegration } from "./utils/has-integration.js";
+export { watchIntegration } from "./utils/watch-integration.js";

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -3,3 +3,4 @@ export { addVitePlugin } from "./utils/add-vite-plugin.js";
 export { createResolver } from "./utils/create-resolver.js";
 export { defineIntegration } from "./utils/define-integration.js";
 export { watchIntegration } from "./utils/watch-integration.js";
+export { hasIntegration } from "./utils/has-integration.js";

--- a/package/src/utils/has-integration.ts
+++ b/package/src/utils/has-integration.ts
@@ -1,0 +1,51 @@
+import type { HookParameters } from "astro";
+import { useHookParams } from "../internal/use-hook-params.js";
+
+type Params = {
+	name: string;
+	config: HookParameters<"astro:config:setup">["config"];
+};
+
+const _hasIntegration = ({ name, config }: Params) => {
+	return !!config.integrations.find((integration) => integration.name === name);
+};
+
+/**
+ * Checks whether an integration is already installed.
+ *
+ * @param {string} name
+ *
+ * @returns {boolean}
+ *
+ * @see https://astro-integration-kit.netlify.app/utilities/has-integration/
+ *
+ * @example
+ * ```ts
+ *  hasIntegration("@astrojs/tailwind") // true
+ * ```
+ */
+export const hasIntegration = (name: Params["name"]): boolean => {
+	const { config } = useHookParams("astro:config:setup");
+
+	return _hasIntegration({ name, config });
+};
+
+/**
+ * Checks whether an integration is already installed.
+ *
+ * @param {object} params
+ * @param {string} params.name
+ * @param {config} params.config
+ *
+ * @returns {boolean}
+ *
+ * @see https://astro-integration-kit.netlify.app/utilities/has-integration/
+ *
+ * @example
+ * ```ts
+ *  vanillaHasIntegration("@astrojs/tailwind") // true
+ * ```
+ */
+export const vanillaHasIntegration = (params: Params): boolean => {
+	return _hasIntegration(params);
+};

--- a/package/src/utils/has-integration.ts
+++ b/package/src/utils/has-integration.ts
@@ -21,7 +21,7 @@ const _hasIntegration = ({ name, config }: Params) => {
  *
  * @example
  * ```ts
- *  hasIntegration("@astrojs/tailwind") // true
+ *  hasIntegration("@astrojs/tailwind")
  * ```
  */
 export const hasIntegration = (name: Params["name"]): boolean => {
@@ -43,7 +43,7 @@ export const hasIntegration = (name: Params["name"]): boolean => {
  *
  * @example
  * ```ts
- *  vanillaHasIntegration("@astrojs/tailwind") // true
+ *  vanillaHasIntegration("@astrojs/tailwind")
  * ```
  */
 export const vanillaHasIntegration = (params: Params): boolean => {

--- a/package/src/utils/has-integration.ts
+++ b/package/src/utils/has-integration.ts
@@ -43,7 +43,7 @@ export const hasIntegration = (name: Params["name"]): boolean => {
  *
  * @example
  * ```ts
- *  vanillaHasIntegration("@astrojs/tailwind")
+ *  hasIntegration("@astrojs/tailwind")
  * ```
  */
 export const vanillaHasIntegration = (params: Params): boolean => {

--- a/package/src/vanilla.ts
+++ b/package/src/vanilla.ts
@@ -1,3 +1,4 @@
 export { vanillaAddVirtualImport as addVirtualImport } from "./utils/add-virtual-import.js";
 export { vanillaAddVitePlugin as addVitePlugin } from "./utils/add-vite-plugin.js";
 export { vanillaWatchIntegration as watchIntegration } from "./utils/watch-integration.js";
+export { vanillaHasIntegration as hasIntegration } from "./utils/has-integration.js";

--- a/package/src/vanilla.ts
+++ b/package/src/vanilla.ts
@@ -1,4 +1,4 @@
 export { vanillaAddVirtualImport as addVirtualImport } from "./utils/add-virtual-import.js";
 export { vanillaAddVitePlugin as addVitePlugin } from "./utils/add-vite-plugin.js";
-export { vanillaWatchIntegration as watchIntegration } from "./utils/watch-integration.js";
 export { vanillaHasIntegration as hasIntegration } from "./utils/has-integration.js";
+export { vanillaWatchIntegration as watchIntegration } from "./utils/watch-integration.js";

--- a/playground/integration/index.ts
+++ b/playground/integration/index.ts
@@ -28,7 +28,7 @@ const testIntegration = defineIntegration<{ name?: string | undefined }>({
 				});
 
 				if (hasIntegration("@astrojs/tailwind")) {
-					console.log("Tailwind in installed");
+					console.log("Tailwind is installed");
 				}
 			},
 		};

--- a/playground/integration/index.ts
+++ b/playground/integration/index.ts
@@ -1,6 +1,7 @@
 import {
 	createResolver,
 	defineIntegration,
+	hasIntegration,
 	watchIntegration,
 } from "astro-integration-kit";
 import { addVirtualImport } from "astro-integration-kit/vanilla";
@@ -25,6 +26,10 @@ const testIntegration = defineIntegration<{ name?: string | undefined }>({
 					content: `export default ${JSON.stringify({ foo: "bar" })}`,
 					updateConfig,
 				});
+
+				if (hasIntegration("@astrojs/tailwind")) {
+					console.log("Tailwind in installed");
+				}
 			},
 		};
 	},


### PR DESCRIPTION
Adds `hasIntegration` util

Example:

```ts
import { hasIntegration } from "astro-integration-kit";

export default defineIntegration({
  name: "my-integration",
  setup() {
    return {
      "astro:config:setup": () => {
        if (hasIntegration("@astrojs/tailwind")) {
          console.log("Tailwind already installed");
        }
      }
    }
  }
})
```

closes #15