### PR TITLE
feat: extend built-in integration hooks

### DIFF
--- a/docs/src/content/docs/utilities/define-integration.mdx
+++ b/docs/src/content/docs/utilities/define-integration.mdx
@@ -6,7 +6,7 @@ description: Makes creating integrations easier, and adds a few goodies!
 `defineIntegration` makes creating integrations easier, and adds a few goodies!
 
 :::caution
-`definIntegration` is required for All-in mode.
+`defineIntegration` is required for All-in mode.
 :::
 
 ```ts title="my-integration/index.ts"
@@ -34,6 +34,27 @@ export default defineIntegration<{ foo?: string }>({
 ### Options
 
 The `defaults` configuration accepts the default values for your integration's options. `defaults` will be deeply merged with the options provided by the user. Please note that this is not runtime safe, it's good practice to check the types of your options inside `setup`.
+
+### Additional hooks
+
+Utilities provided by `astro-integration-kit` such as `addVitePlugin` and `addVirtualModule` are made directly available in their appropriate hooks.
+
+```ts
+import { defineIntegration } from "astro-integration-kit";
+
+export default defineIntegration<{}>({
+	name: "my-awesome-integration",
+	defaults: {},
+	setup: () => ({
+		"astro:config:setup"({ addVirtualImport }) {
+			addVirtualImport({
+				name: "virtual:astro-integration-kit-playground/config",
+				content: `export default ${JSON.stringify({ foo: "bar" })}`
+			})
+		}
+	})
+})
+```
 
 ### Context & All-in mode
 

--- a/package/src/utils/add-virtual-import.ts
+++ b/package/src/utils/add-virtual-import.ts
@@ -7,7 +7,7 @@ const resolveVirtualModuleId = <T extends string>(id: T): `\0${T}` => {
 	return `\0${id}`;
 };
 
-const createVirtualModule = (name: string, content: string): Plugin => {
+export const createVirtualModule = (name: string, content: string): Plugin => {
 	const pluginName = `vite-plugin-${name}`;
 
 	return {

--- a/package/src/utils/define-integration.ts
+++ b/package/src/utils/define-integration.ts
@@ -2,6 +2,7 @@ import type { AstroIntegration } from "astro";
 import { defu } from "defu";
 import { DEFAULT_HOOKS_NAMES } from "../internal/constants.js";
 import { hookContext } from "../internal/context.js";
+import { addVitePlugin } from "../vanilla.js";
 import { createVirtualModule } from "../utils/add-virtual-import.js"
 
 /**
@@ -50,10 +51,12 @@ export const defineIntegration = <
 
 		const hooks: AstroIntegration["hooks"] = {
 			"astro:config:setup"(params) {
-				const addVitePlugin: AddVitePlugin = plugin => void params.updateConfig({ vite: { plugins: [plugin] } });
-				const addVirtualImport: AddVirtualImport = ({ name, content }) => addVitePlugin(createVirtualModule(name, content));
 				hookContext.callAsync({ "astro:config:setup": params }, () => {
-					providedHooks["astro:config:setup"]?.({ ...params, addVirtualImport, addVitePlugin });
+					providedHooks["astro:config:setup"]?.({
+						...params,
+						addVirtualImport: ({ name, content }) => addVitePlugin({ plugin: createVirtualModule(name, content), updateConfig: params.updateConfig }),
+						addVitePlugin: plugin => addVitePlugin({ plugin, updateConfig: params.updateConfig }),
+					});
 				})
 			}
 		};

--- a/package/src/utils/define-integration.ts
+++ b/package/src/utils/define-integration.ts
@@ -41,7 +41,7 @@ export const defineIntegration = <
 	setup: (params: {
 		name: string;
 		options: TOptions;
-	}) => ExtendedAstroIntegration["hooks"];
+	}) => ExtendedHooks;
 }): ((options: TOptions) => AstroIntegration) => {
 	return (_options) => {
 		const options = defu(_options, defaults ?? {}) as TOptions;
@@ -77,14 +77,10 @@ export const defineIntegration = <
 	};
 };
 
-interface ExtendedAstroIntegration extends AstroIntegration {
-	hooks: Hooks & HookExtension;
-}
-
 type Hooks = NonNullable<AstroIntegration["hooks"]>
 
-interface HookExtension {
-	"astro:config:setup": AddParam<Hooks["astro:config:setup"], { addVitePlugin: AddVitePlugin, addVirtualImport: AddVirtualImport }>;
+interface ExtendedHooks extends Omit<Hooks, "astro:config:setup"> {
+	"astro:config:setup"?: AddParam<Hooks["astro:config:setup"], { addVitePlugin: AddVitePlugin, addVirtualImport: AddVirtualImport }>;
 }
 
 type AddVitePlugin = (plugin: import("vite").Plugin) => void;


### PR DESCRIPTION
# Changes

- Sets up code and types for extending hooks.
- Implements addVirtualImport, and addVitePlugin using it.

```ts
import { defineIntegration } from "astro-integration-kit";

export default defineIntegration<{}>({
	name: "my-awesome-integration",
	defaults: {},
	setup: () => ({
		"astro:config:setup"({ addVirtualImport }) {
			addVirtualImport({
				name: "virtual:astro-integration-kit-playground/config",
				content: `export default ${JSON.stringify({ foo: "bar" })}`
			})
		}
	})
})
```

# Docs
- Added a section in define-integration.mdx

# Testing
😶‍🌫️