### PR TITLE
Update add-dts.mdx

### DIFF
--- a/docs/src/content/docs/utilities/add-dts.mdx
+++ b/docs/src/content/docs/utilities/add-dts.mdx
@@ -4,7 +4,7 @@ description: Allows to inject .d.ts file in users project. It will create a file
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-`addVitePlugin` allows you to inject `.d.ts` file in users project. It will
+`addDts` allows you to inject `.d.ts` file in the user's project. It will
 create a file inside `.astro` and reference it from `src/env.d.ts`. For example:
 
 <Tabs>

--- a/docs/src/content/docs/utilities/add-dts.mdx
+++ b/docs/src/content/docs/utilities/add-dts.mdx
@@ -4,7 +4,7 @@ description: Allows to inject .d.ts file in users project. It will create a file
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
-`addDts` allows you to inject `.d.ts` file in the user's project. It will
+`addDts` allows you to inject a `.d.ts` file into the user's project. It will
 create a file inside `.astro` and reference it from `src/env.d.ts`. For example:
 
 <Tabs>


### PR DESCRIPTION
Fixes a typo that incorrectly referred to `addVitePlugin` instead of `addDts`.