### PR TITLE
update export to use js

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -20,7 +20,7 @@
 	},
 	"sideEffects": false,
 	"exports": {
-		".": "./src/index.ts"
+		".": "./src/index.js"
 	},
 	"scripts": {
 		"test": "vitest"


### PR DESCRIPTION
This seems to work in the playground, but I'm not 100% if it's needed. Other than that I certainly couldn't see anymore instances where we're not import from `.js` now. So even if this PR isn't needed, then #7 should still close but otherwise closes #7