### PR TITLE
feat: improve error messages for optionsSchema parsing

### DIFF
--- a/.changeset/mean-islands-rescue.md
+++ b/.changeset/mean-islands-rescue.md
@@ -2,4 +2,4 @@
 "astro-integration-kit": patch
 ---
 
-Improve error messages for invalid options schema
+Improves error messages for `optionsSchema` parsing

--- a/.changeset/mean-islands-rescue.md
+++ b/.changeset/mean-islands-rescue.md
@@ -1,0 +1,5 @@
+---
+"astro-integration-kit": patch
+---
+
+Improve error messages for invalid options schema

--- a/package/src/core/define-integration.ts
+++ b/package/src/core/define-integration.ts
@@ -1,8 +1,8 @@
 import type { AstroIntegration, HookParameters } from "astro";
-import type { z } from "astro/zod";
 import { AstroError } from "astro/errors";
-import { errorMap } from "../internal/error-map.js";
+import type { z } from "astro/zod";
 import { DEFAULT_HOOK_NAMES } from "../internal/constants.js";
+import { errorMap } from "../internal/error-map.js";
 import type { AnyPlugin, ExtendedHooks } from "./types.js";
 
 /**
@@ -50,11 +50,12 @@ export const defineIntegration = <
 		if (parsedOptions && !parsedOptions.success) {
 			throw new AstroError(
 				`Invalid configuration passed to '${name}' integration\n`,
-					parsedOptions.error.issues.map((i) => i.message).join('\n')
+				parsedOptions.error.issues.map((i) => i.message).join("\n"),
 			);
 		}
 
-		const options = (parsedOptions?.data || _options) as z.output<TOptionsSchema>
+		const options = (parsedOptions?.data ||
+			_options) as z.output<TOptionsSchema>;
 
 		const resolvedPlugins = Object.values(
 			(() => {

--- a/package/src/core/define-integration.ts
+++ b/package/src/core/define-integration.ts
@@ -28,7 +28,7 @@ import type { AnyPlugin, ExtendedHooks } from "./types.js";
  * ```
  */
 export const defineIntegration = <
-	TOptionsSchema extends import("astro/zod").AnyZodObject,
+	TOptionsSchema extends z.AnyZodObject = z.AnyZodObject,
 	TPlugins extends Array<AnyPlugin> = [],
 >({
 	name,

--- a/package/src/core/define-integration.ts
+++ b/package/src/core/define-integration.ts
@@ -32,7 +32,7 @@ export const defineIntegration = <
 	TPlugins extends Array<AnyPlugin> = [],
 >({
 	name,
-	optionsSchema = z.object({}) as TOptionsSchema,
+	optionsSchema,
 	setup,
 	plugins: _plugins,
 }: {
@@ -45,7 +45,7 @@ export const defineIntegration = <
 	}) => ExtendedHooks<TPlugins>;
 }): ((options?: z.input<TOptionsSchema>) => AstroIntegration) => {
 	return (_options: z.input<TOptionsSchema> = {}) => {
-		const parsedOptions = optionsSchema.safeParse(_options, { errorMap });
+		const parsedOptions = (optionsSchema || z.record(z.any())).safeParse(_options, { errorMap });
 
 		if (!parsedOptions.success) {
 			throw new AstroError(

--- a/package/src/core/define-integration.ts
+++ b/package/src/core/define-integration.ts
@@ -1,5 +1,7 @@
 import type { AstroIntegration, HookParameters } from "astro";
 import type { z } from "astro/zod";
+import { AstroError } from "astro/errors";
+import { errorMap } from "../internal/error-map.js";
 import { DEFAULT_HOOK_NAMES } from "../internal/constants.js";
 import type { AnyPlugin, ExtendedHooks } from "./types.js";
 
@@ -43,7 +45,16 @@ export const defineIntegration = <
 	}) => ExtendedHooks<TPlugins>;
 }): ((options?: z.input<TOptionsSchema>) => AstroIntegration) => {
 	return (_options: z.input<TOptionsSchema> = {}) => {
-		const options = optionsSchema?.parse(_options) as z.output<TOptionsSchema>;
+		const parsedOptions = optionsSchema?.safeParse(_options, { errorMap });
+
+		if (parsedOptions && !parsedOptions.success) {
+			throw new AstroError(
+				`Invalid configuration passed to '${name}' integration\n`,
+					parsedOptions.error.issues.map((i) => i.message).join('\n')
+			);
+		}
+
+		const options = (parsedOptions?.data || _options) as z.output<TOptionsSchema>
 
 		const resolvedPlugins = Object.values(
 			(() => {

--- a/package/src/internal/error-map.ts
+++ b/package/src/internal/error-map.ts
@@ -1,6 +1,6 @@
-// https://github.com/withastro/astro/blob/d278e66ec6ded7a3ad441e6c3c5f9c265217936f/packages/astro/src/content/error-map.ts
-
 import type { ZodErrorMap } from "astro/zod";
+
+// Source: https://github.com/withastro/astro/blob/d278e66ec6ded7a3ad441e6c3c5f9c265217936f/packages/astro/src/content/error-map.ts
 
 type TypeOrLiteralErrByPathEntry = {
 	code: "invalid_type" | "invalid_literal";

--- a/package/src/internal/error-map.ts
+++ b/package/src/internal/error-map.ts
@@ -1,0 +1,99 @@
+import type { ZodErrorMap } from 'astro/zod';
+
+type TypeOrLiteralErrByPathEntry = {
+	code: 'invalid_type' | 'invalid_literal';
+	received: unknown;
+	expected: unknown[];
+};
+
+export const errorMap: ZodErrorMap = (baseError, ctx) => {
+	const baseErrorPath = flattenErrorPath(baseError.path);
+	if (baseError.code === 'invalid_union') {
+		// Optimization: Combine type and literal errors for keys that are common across ALL union types
+		// Ex. a union between `{ key: z.literal('tutorial') }` and `{ key: z.literal('blog') }` will
+		// raise a single error when `key` does not match:
+		// > Did not match union.
+		// > key: Expected `'tutorial' | 'blog'`, received 'foo'
+		let typeOrLiteralErrByPath = new Map<string, TypeOrLiteralErrByPathEntry>();
+		for (const unionError of baseError.unionErrors.map((e) => e.errors).flat()) {
+			if (unionError.code === 'invalid_type' || unionError.code === 'invalid_literal') {
+				const flattenedErrorPath = flattenErrorPath(unionError.path);
+				if (typeOrLiteralErrByPath.has(flattenedErrorPath)) {
+					typeOrLiteralErrByPath.get(flattenedErrorPath)!.expected.push(unionError.expected);
+				} else {
+					typeOrLiteralErrByPath.set(flattenedErrorPath, {
+						code: unionError.code,
+						received: (unionError as any).received,
+						expected: [unionError.expected],
+					});
+				}
+			}
+		}
+		let messages: string[] = [
+			prefix(
+				baseErrorPath,
+				typeOrLiteralErrByPath.size ? 'Did not match union:' : 'Did not match union.'
+			),
+		];
+		return {
+			message: messages
+				.concat(
+					[...typeOrLiteralErrByPath.entries()]
+						// If type or literal error isn't common to ALL union types,
+						// filter it out. Can lead to confusing noise.
+						.filter(([, error]) => error.expected.length === baseError.unionErrors.length)
+						.map(([key, error]) =>
+							key === baseErrorPath
+								? // Avoid printing the key again if it's a base error
+									`> ${getTypeOrLiteralMsg(error)}`
+								: `> ${prefix(key, getTypeOrLiteralMsg(error))}`
+						)
+				)
+				.join('\n'),
+		};
+	}
+	if (baseError.code === 'invalid_literal' || baseError.code === 'invalid_type') {
+		return {
+			message: prefix(
+				baseErrorPath,
+				getTypeOrLiteralMsg({
+					code: baseError.code,
+					received: (baseError as any).received,
+					expected: [baseError.expected],
+				})
+			),
+		};
+	} else if (baseError.message) {
+		return { message: prefix(baseErrorPath, baseError.message) };
+	} else {
+		return { message: prefix(baseErrorPath, ctx.defaultError) };
+	}
+};
+
+const getTypeOrLiteralMsg = (error: TypeOrLiteralErrByPathEntry): string => {
+	if (error.received === 'undefined') return 'Required';
+	const expectedDeduped = new Set(error.expected);
+	switch (error.code) {
+		case 'invalid_type':
+			return `Expected type \`${unionExpectedVals(expectedDeduped)}\`, received ${JSON.stringify(
+				error.received
+			)}`;
+		case 'invalid_literal':
+			return `Expected \`${unionExpectedVals(expectedDeduped)}\`, received ${JSON.stringify(
+				error.received
+			)}`;
+	}
+};
+
+const prefix = (key: string, msg: string) => (key.length ? `**${key}**: ${msg}` : msg);
+
+const unionExpectedVals = (expectedVals: Set<unknown>) =>
+	[...expectedVals]
+		.map((expectedVal, idx) => {
+			if (idx === 0) return JSON.stringify(expectedVal);
+			const sep = ' | ';
+			return `${sep}${JSON.stringify(expectedVal)}`;
+		})
+		.join('');
+
+const flattenErrorPath = (errorPath: (string | number)[]) => errorPath.join('.');

--- a/package/src/internal/error-map.ts
+++ b/package/src/internal/error-map.ts
@@ -1,28 +1,35 @@
-
 // https://github.com/withastro/astro/blob/d278e66ec6ded7a3ad441e6c3c5f9c265217936f/packages/astro/src/content/error-map.ts
 
-import type { ZodErrorMap } from 'astro/zod';
+import type { ZodErrorMap } from "astro/zod";
 
 type TypeOrLiteralErrByPathEntry = {
-	code: 'invalid_type' | 'invalid_literal';
+	code: "invalid_type" | "invalid_literal";
 	received: unknown;
 	expected: unknown[];
 };
 
 export const errorMap: ZodErrorMap = (baseError, ctx) => {
 	const baseErrorPath = flattenErrorPath(baseError.path);
-	if (baseError.code === 'invalid_union') {
+	if (baseError.code === "invalid_union") {
 		// Optimization: Combine type and literal errors for keys that are common across ALL union types
 		// Ex. a union between `{ key: z.literal('tutorial') }` and `{ key: z.literal('blog') }` will
 		// raise a single error when `key` does not match:
 		// > Did not match union.
 		// > key: Expected `'tutorial' | 'blog'`, received 'foo'
-		let typeOrLiteralErrByPath = new Map<string, TypeOrLiteralErrByPathEntry>();
-		for (const unionError of baseError.unionErrors.map((e) => e.errors).flat()) {
-			if (unionError.code === 'invalid_type' || unionError.code === 'invalid_literal') {
+		const typeOrLiteralErrByPath = new Map<
+			string,
+			TypeOrLiteralErrByPathEntry
+		>();
+		for (const unionError of baseError.unionErrors.flatMap((e) => e.errors)) {
+			if (
+				unionError.code === "invalid_type" ||
+				unionError.code === "invalid_literal"
+			) {
 				const flattenedErrorPath = flattenErrorPath(unionError.path);
 				if (typeOrLiteralErrByPath.has(flattenedErrorPath)) {
-					typeOrLiteralErrByPath.get(flattenedErrorPath)!.expected.push(unionError.expected);
+					typeOrLiteralErrByPath
+						.get(flattenedErrorPath)!
+						.expected.push(unionError.expected);
 				} else {
 					typeOrLiteralErrByPath.set(flattenedErrorPath, {
 						code: unionError.code,
@@ -32,10 +39,12 @@ export const errorMap: ZodErrorMap = (baseError, ctx) => {
 				}
 			}
 		}
-		let messages: string[] = [
+		const messages: string[] = [
 			prefix(
 				baseErrorPath,
-				typeOrLiteralErrByPath.size ? 'Did not match union:' : 'Did not match union.'
+				typeOrLiteralErrByPath.size
+					? "Did not match union:"
+					: "Did not match union.",
 			),
 		];
 		return {
@@ -44,18 +53,24 @@ export const errorMap: ZodErrorMap = (baseError, ctx) => {
 					[...typeOrLiteralErrByPath.entries()]
 						// If type or literal error isn't common to ALL union types,
 						// filter it out. Can lead to confusing noise.
-						.filter(([, error]) => error.expected.length === baseError.unionErrors.length)
+						.filter(
+							([, error]) =>
+								error.expected.length === baseError.unionErrors.length,
+						)
 						.map(([key, error]) =>
 							key === baseErrorPath
 								? // Avoid printing the key again if it's a base error
-									`> ${getTypeOrLiteralMsg(error)}`
-								: `> ${prefix(key, getTypeOrLiteralMsg(error))}`
-						)
+								  `> ${getTypeOrLiteralMsg(error)}`
+								: `> ${prefix(key, getTypeOrLiteralMsg(error))}`,
+						),
 				)
-				.join('\n'),
+				.join("\n"),
 		};
 	}
-	if (baseError.code === 'invalid_literal' || baseError.code === 'invalid_type') {
+	if (
+		baseError.code === "invalid_literal" ||
+		baseError.code === "invalid_type"
+	) {
 		return {
 			message: prefix(
 				baseErrorPath,
@@ -63,7 +78,7 @@ export const errorMap: ZodErrorMap = (baseError, ctx) => {
 					code: baseError.code,
 					received: (baseError as any).received,
 					expected: [baseError.expected],
-				})
+				}),
 			),
 		};
 	} else if (baseError.message) {
@@ -74,29 +89,31 @@ export const errorMap: ZodErrorMap = (baseError, ctx) => {
 };
 
 const getTypeOrLiteralMsg = (error: TypeOrLiteralErrByPathEntry): string => {
-	if (error.received === 'undefined') return 'Required';
+	if (error.received === "undefined") return "Required";
 	const expectedDeduped = new Set(error.expected);
 	switch (error.code) {
-		case 'invalid_type':
-			return `Expected type \`${unionExpectedVals(expectedDeduped)}\`, received ${JSON.stringify(
-				error.received
-			)}`;
-		case 'invalid_literal':
-			return `Expected \`${unionExpectedVals(expectedDeduped)}\`, received ${JSON.stringify(
-				error.received
-			)}`;
+		case "invalid_type":
+			return `Expected type \`${unionExpectedVals(
+				expectedDeduped,
+			)}\`, received ${JSON.stringify(error.received)}`;
+		case "invalid_literal":
+			return `Expected \`${unionExpectedVals(
+				expectedDeduped,
+			)}\`, received ${JSON.stringify(error.received)}`;
 	}
 };
 
-const prefix = (key: string, msg: string) => (key.length ? `**${key}**: ${msg}` : msg);
+const prefix = (key: string, msg: string) =>
+	key.length ? `**${key}**: ${msg}` : msg;
 
 const unionExpectedVals = (expectedVals: Set<unknown>) =>
 	[...expectedVals]
 		.map((expectedVal, idx) => {
 			if (idx === 0) return JSON.stringify(expectedVal);
-			const sep = ' | ';
+			const sep = " | ";
 			return `${sep}${JSON.stringify(expectedVal)}`;
 		})
-		.join('');
+		.join("");
 
-const flattenErrorPath = (errorPath: (string | number)[]) => errorPath.join('.');
+const flattenErrorPath = (errorPath: (string | number)[]) =>
+	errorPath.join(".");

--- a/package/src/internal/error-map.ts
+++ b/package/src/internal/error-map.ts
@@ -1,3 +1,6 @@
+
+// https://github.com/withastro/astro/blob/d278e66ec6ded7a3ad441e6c3c5f9c265217936f/packages/astro/src/content/error-map.ts
+
 import type { ZodErrorMap } from 'astro/zod';
 
 type TypeOrLiteralErrByPathEntry = {


### PR DESCRIPTION
Safe parse the options schema, throw a formatted error if it is invalid using Astro's [`error-map.ts`](https://github.com/withastro/astro/blob/d278e66ec6ded7a3ad441e6c3c5f9c265217936f/packages/astro/src/content/error-map.ts)

**Before**:
![old](https://github.com/florian-lefebvre/astro-integration-kit/assets/19967622/0ce250b5-a3c3-4582-af4c-2e6e3a63d525)

**After**:
![new](https://github.com/florian-lefebvre/astro-integration-kit/assets/19967622/7d16b3e3-4d06-4870-b81b-0ecb509d4228)
