### PR TITLE
feat: update optionsSchema constraint

### DIFF
--- a/.changeset/pretty-dancers-care.md
+++ b/.changeset/pretty-dancers-care.md
@@ -1,0 +1,5 @@
+---
+"astro-integration-kit": patch
+---
+
+Updates the `optionsSchema` constraint to allow any schema shape

--- a/package/src/core/define-integration.ts
+++ b/package/src/core/define-integration.ts
@@ -28,7 +28,7 @@ import type { AnyPlugin, ExtendedHooks } from "./types.js";
  * ```
  */
 export const defineIntegration = <
-	TOptionsSchema extends z.AnyZodObject = z.AnyZodObject,
+	TOptionsSchema extends z.ZodTypeAny = z.ZodTypeAny,
 	TPlugins extends Array<AnyPlugin> = [],
 >({
 	name,

--- a/playground/astro.config.mts
+++ b/playground/astro.config.mts
@@ -7,7 +7,7 @@ export default defineConfig({
 	integrations: [
 		tailwind(),
 		testIntegration({
-			resource: "abc",
+			resource: "a",
 		}),
 		{ name: "integration-a", hooks: {} },
 		{ name: "integration-b", hooks: {} },

--- a/playground/integration/index.ts
+++ b/playground/integration/index.ts
@@ -3,19 +3,24 @@ import { createResolver, defineIntegration } from "astro-integration-kit";
 import { corePlugins } from "astro-integration-kit/plugins";
 import { z } from "astro/zod";
 
-const OptionsSchema = z.object({
-	/**
-	 * The name of the resource.
-	 */
-	resource: z
-		.string()
-		.default("abc")
-		.transform((val) => val.length),
-});
+const optionsSchema = z
+	.object({
+		/**
+		 * The name of the resource.
+		 */
+		resource: z
+			.string()
+			.default("abc")
+			.transform((val) => val.length),
+	})
+	.refine((val) => val.resource > 1, {
+		message: "Must be at least 2 chars long",
+		path: ["resource"],
+	});
 
 const testIntegration = defineIntegration({
 	name: "test-integration",
-	optionsSchema: OptionsSchema,
+	optionsSchema,
 	plugins: [...corePlugins],
 	setup: ({ options }) => {
 		const { resolve } = createResolver(import.meta.url);


### PR DESCRIPTION
Closes #70

This allows to use stuff like `.refine`, or really any schema shape (want an array? do it!)