### PR TITLE
fix(docs): update installation not to install AIK as dev dep

### DIFF
--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -10,17 +10,17 @@ Add `astro-integration-kit` using your favorite package manager:
 <Tabs>
     <TabItem label="npm">
     ```bash
-    npm install -D astro-integration-kit
+    npm install astro-integration-kit
     ```
     </TabItem>
     <TabItem label="yarn">
     ```bash
-    yarn add -D astro-integration-kit
+    yarn add astro-integration-kit
     ```
     </TabItem>
     <TabItem label="pnpm">
     ```bash
-    pnpm add -D astro-integration-kit
+    pnpm add astro-integration-kit
     ```
     </TabItem>
 </Tabs>


### PR DESCRIPTION
Since we recommend shipping ts files directly (eg my template), it's probably worth removing the recommendation of installing aik as a dev dependency.