### PR TITLE
fix: wrong virtual import content

### DIFF
--- a/.changeset/hungry-crabs-add.md
+++ b/.changeset/hungry-crabs-add.md
@@ -1,0 +1,5 @@
+---
+"astro-integration-kit": patch
+---
+
+Fixes a case where the wrong content was passed when using `addVirtualImports` with `imports` as an array

--- a/package/src/utilities/add-virtual-imports.ts
+++ b/package/src/utilities/add-virtual-imports.ts
@@ -79,10 +79,12 @@ const createVirtualModule = (
 			const resolution = resolutionMap[id];
 			if (resolution) {
 				const context = options?.ssr ? "server" : "client";
-				const data = imports.find((_import) =>
-					_import.id === resolution && _import.context === undefined
-						? true
-						: _import.context === context,
+				const data = imports.find(
+					(_import) =>
+						_import.id === resolution &&
+						(_import.context === undefined
+							? true
+							: _import.context === context),
 				);
 
 				if (data) {

--- a/playground/integration/index.ts
+++ b/playground/integration/index.ts
@@ -240,7 +240,7 @@ const testIntegration = defineIntegration({
 							include: ["**/*.solid.jsx"],
 						}),
 					});
-
+					/*
 					addDevToolbarFrameworkApp(params, {
 						framework: "react",
 						name: "Test React Plugin 1 ",
@@ -361,6 +361,7 @@ const testIntegration = defineIntegration({
 					`,
 						src: resolve("./devToolbarApps/Test.solid.jsx"),
 					});
+					*/
 
 					console.log(
 						"VITE PLUGINS",
@@ -369,6 +370,27 @@ const testIntegration = defineIntegration({
 
 					// Test addVirtualImports disallowed list
 					// addVirtualImports({ "astro:test": "export default {}" });
+
+					addVirtualImports(params, {
+						name: "whatever",
+						imports: [
+							{
+								id: "whatever-a",
+								content: "export const foo = 'bar'",
+								context: "server",
+							},
+							{
+								id: "whatever-b",
+								content: "export const abc = 'def'",
+								context: "server",
+							},
+							{
+								id: "whatever-b",
+								content: "export const abc = 'def'",
+								context: "client",
+							},
+						],
+					});
 				},
 			},
 		});

--- a/playground/src/pages/virtual-module.astro
+++ b/playground/src/pages/virtual-module.astro
@@ -8,6 +8,12 @@ import arraySimple from "virtual:playground/array-simple"
 import arrayComplex from "virtual:playground/array-complex"
 
 import Layout from "../layouts/Layout.astro";
+
+// @ts-ignore
+import * as whateverA from "whatever-a"
+// @ts-ignore
+import * as whateverB from "whatever-b"
+console.log({ whateverA, whateverB })
 ---
 
 <Layout title="Testing Virtual Module">


### PR DESCRIPTION
If you have a look at the playground diff, before this PR `whatever-b` would also return `whatever-a`'s content