### PR TITLE
fix: Allow plugins to initalize themselves on unused hooks

### DIFF
--- a/.changeset/cool-islands-brake.md
+++ b/.changeset/cool-islands-brake.md
@@ -1,0 +1,5 @@
+---
+"astro-integration-kit": patch
+---
+
+Fixes initialization of plugins when necessary hooks are not used by consumer integrations

--- a/package/src/core/with-plugins.ts
+++ b/package/src/core/with-plugins.ts
@@ -56,7 +56,12 @@ export const withPlugins = <
 			> => plugin.setup({ name }),
 		);
 
-	const definedHooks = Object.keys(providedHooks) as Array<keyof Hooks>;
+	const definedHooks = ([
+		...Object.keys(providedHooks),
+		...resolvedPlugins.flatMap(Object.keys),
+	] as Array<keyof Hooks>)
+		// Deduplicate the hook names
+		.filter((hookName, index, list) => list.indexOf(hookName) === index);
 
 	const hooks: AstroIntegration["hooks"] = Object.fromEntries(
 		definedHooks.map((hookName) => [

--- a/package/tests/unit/with-plugins.spec.ts
+++ b/package/tests/unit/with-plugins.spec.ts
@@ -22,8 +22,11 @@ describe('withPlugins', () => {
             },
           };
         },
-        'astro:server:done': () => ({
-          getState: () => innerState,
+        'astro:server:done': ({ logger }) => ({
+          getState: () => {
+            logger.info('Reading state');
+            return innerState;
+          },
         }),
       };
     },
@@ -86,6 +89,7 @@ describe('withPlugins', () => {
     expect(logger.log).toStrictEqual([
       'Called from plugin "foo" on integration "my-integration".',
       'Calling "foo" with msg: from integration',
+      'Reading state',
     ]);
   });
 
@@ -150,6 +154,7 @@ describe('withPlugins', () => {
 
     expect(logger.log).toStrictEqual([
       'Called from plugin "foo" on integration "my-integration".',
+      'Reading state'
     ]);
   });
 });

--- a/package/tests/unit/with-plugins.spec.ts
+++ b/package/tests/unit/with-plugins.spec.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import { definePlugin } from "../../src/core/define-plugin.js";
+import { withPlugins } from "../../src/core/with-plugins.js";
+import type { AstroIntegrationLogger } from "astro";
+
+describe('withPlugins', () => {
+  const fooPlugin = definePlugin({
+    name: 'foo',
+    setup({ name }) {
+      let innerState: string = 'initial state';
+
+      return {
+        'astro:build:start': ({ logger }) => {
+          logger.info(`Called from plugin "foo" on integration "${name}".`);
+
+          return {
+            foo: (msg: string) => {
+              logger.info(`Calling "foo" with msg: ${msg}`);
+            },
+            setState: (state: string) => {
+              innerState = state;
+            },
+          };
+        },
+        'astro:server:done': () => ({
+          getState: () => innerState,
+        }),
+      };
+    },
+  });
+
+  const otherFooPlugin = definePlugin({
+    name: 'foo',
+    setup({ name }) {
+      return {
+        'astro:build:start': ({ logger }) => {
+          logger.info(`Called from plugin "otherFoo" on integration "${name}".`);
+
+          return {
+            foo: (msg: string) => {
+              logger.info(`Calling "foo" (from otherFoo) with msg: ${msg}`);
+            }
+          };
+        },
+      };
+    },
+  });
+
+  const barPlugin = definePlugin({
+    name: 'bar',
+    setup({ name }) {
+      return {
+        'astro:build:start': ({ logger }) => {
+          logger.info(`Called from plugin "bar" on integration "${name}".`);
+
+          return {
+            foo: (msg: string) => {
+              logger.info(`Calling "foo" (from bar) with msg: ${msg}`);
+            }
+          };
+        },
+      };
+    },
+  });
+
+  it('should provide the plugins API to the hooks', () => {
+    const integration = withPlugins({
+      name: 'my-integration',
+      plugins: [fooPlugin],
+      hooks: {
+        'astro:build:start': ({ foo, setState }) => {
+          foo('from integration');
+          setState('integrationState')
+        },
+        'astro:server:done': ({ getState }) => {
+          expect(getState()).toEqual('integrationState');
+        },
+      },
+    });
+
+    const logger = new MemoryLogger();
+
+    integration.hooks['astro:build:start']?.({ logger });
+    integration.hooks['astro:server:done']?.({ logger });
+
+    expect(logger.log).toStrictEqual([
+      'Called from plugin "foo" on integration "my-integration".',
+      'Calling "foo" with msg: from integration',
+    ]);
+  });
+
+  it('should override plugins with the same name', () => {
+    const integration = withPlugins({
+      name: 'my-integration',
+      plugins: [fooPlugin, otherFooPlugin],
+      hooks: {
+        'astro:build:start': ({ foo }) => {
+          foo('from integration');
+        }
+      },
+    });
+
+    const logger = new MemoryLogger();
+
+    integration.hooks['astro:build:start']?.({ logger });
+
+    expect(logger.log).toStrictEqual([
+      'Called from plugin "otherFoo" on integration "my-integration".',
+      'Calling "foo" (from otherFoo) with msg: from integration',
+    ]);
+  });
+
+  it('should override plugin APIs with the same name', () => {
+    const integration = withPlugins({
+      name: 'my-integration',
+      plugins: [fooPlugin, barPlugin],
+      hooks: {
+        'astro:build:start': ({ foo }) => {
+          foo('from integration');
+        }
+      },
+    });
+
+    const logger = new MemoryLogger();
+
+    integration.hooks['astro:build:start']?.({ logger });
+
+    expect(logger.log).toStrictEqual([
+      'Called from plugin "foo" on integration "my-integration".',
+      'Called from plugin "bar" on integration "my-integration".',
+      'Calling "foo" (from bar) with msg: from integration',
+    ]);
+  });
+
+  it('should run plugin hooks that are not part of the integration', () => {
+    const integration = withPlugins({
+      name: 'my-integration',
+      plugins: [fooPlugin],
+      hooks: {
+        'astro:server:done': ({ getState }) => {
+          expect(getState()).toEqual('initial state');
+        },
+      },
+    });
+
+    const logger = new MemoryLogger();
+
+    integration.hooks['astro:build:start']?.({ logger });
+    integration.hooks['astro:server:done']?.({ logger });
+
+    expect(logger.log).toStrictEqual([
+      'Called from plugin "foo" on integration "my-integration".',
+    ]);
+  });
+});
+
+class MemoryLogger implements AstroIntegrationLogger {
+  log: string[] = [];
+
+  options = {} as any;
+  label: string = '';
+
+  fork(): AstroIntegrationLogger {
+    return this;
+  }
+
+  info(message: string): void {
+    this.log.push(message);
+  }
+  warn(message: string): void {
+    this.log.push(message);
+  }
+  error(message: string): void {
+    this.log.push(message);
+  }
+  debug(message: string): void {
+    this.log.push(message);
+  }
+}
+


### PR DESCRIPTION
If a plugin requires information from one specific hook to work (like requiring the ssr manifest from `astro:build:ssr` to provide an API for `astro:build:done`) but the integration using the plugin doesn't use that hook, the plugin would not be properly initialized as it would never be called for that hook.

This change makes `withPlugins` such that it defines hooks for all plugin hooks that just call the plugins to create the API and immediately return.

The added tests are for the other behaviors that haven't been tested till now. The last test of the file is for this fix.