### PR TITLE
fix: incorrect URL references to APIs in JSDoc

### DIFF
--- a/package/src/core/create-resolver.ts
+++ b/package/src/core/create-resolver.ts
@@ -6,7 +6,7 @@ import { dirname, resolve } from "pathe";
  *
  * @param {string} _base - The location you want to create relative references from. `import.meta.url` is usually what you'll want.
  *
- * @see https://astro-integration-kit.netlify.app/utilities/create-resolver/
+ * @see https://astro-integration-kit.netlify.app/core/create-resolver/
  *
  * @example
  * ```ts

--- a/package/src/core/define-all-hooks-plugin.ts
+++ b/package/src/core/define-all-hooks-plugin.ts
@@ -23,7 +23,7 @@ export type AllHooksPlugin<TName extends string, TApi extends Record<string, unk
  * called dynamically for each hook. This allows plugins to support any hook
  * even those added by new versions of astro or hooks added by other integrations.
  *
- * @see https://astro-integration-kit.netlify.app/utilities/define-plugin/
+ * @see https://astro-integration-kit.netlify.app/core/define-plugin/
  */
 export const defineAllHooksPlugin = <TName extends string, TApi extends Record<string, unknown>>(
   plugin: AllHooksPluginDefinition<TName, TApi>

--- a/package/src/core/define-integration.ts
+++ b/package/src/core/define-integration.ts
@@ -21,7 +21,7 @@ type AstroIntegrationSetupFn<Options extends z.ZodTypeAny, TApi> = (params: {
  * @param {import("astro/zod").AnyZodObject} params.optionsSchema - An optional zod schema to handle your integration options
  * @param {function} params.setup - This will be called from your `astro:config:setup` call with the user options
  *
- * @see https://astro-integration-kit.netlify.app/utilities/define-integration/
+ * @see https://astro-integration-kit.netlify.app/core/define-integration/
  *
  * @example
  * ```ts

--- a/package/src/core/define-plugin.ts
+++ b/package/src/core/define-plugin.ts
@@ -8,7 +8,7 @@ import type { Plugin, PluginHooksConstraint } from "./types.js";
  * @param {string} plugin.hook - The name of the hook where this plugin should be available
  * @param {Function} plugin.implementation - The actual function definition. Refer to docs for usage
  *
- * @see https://astro-integration-kit.netlify.app/utilities/define-plugin/
+ * @see https://astro-integration-kit.netlify.app/core/define-plugin/
  *
  * ```ts
  * import { definePlugin } from "../core/define-plugin.js";

--- a/package/src/core/define-utility.ts
+++ b/package/src/core/define-utility.ts
@@ -18,7 +18,7 @@ export type HookUtility<
  *
  * @param {string} _hook
  *
- * @see https://astro-integration-kit.netlify.app/utilities/define-utility/
+ * @see https://astro-integration-kit.netlify.app/core/define-utility/
  *
  * @example
  * ```ts


### PR DESCRIPTION
Hey, not sure when this happened, but all these led to 404s on your docs site. I just pointed them to the right URL. LMK if I missed something.

---
💖